### PR TITLE
Nolus positions tracking

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -15,7 +15,7 @@ import (
 const (
 	Debug   = true
 	Address = "osmo1cuwe7dzgpemwxqzpkhyjwfeev2hcgd9de8xp566hrly6wtpcrc7qgp9jdx"
-	BidId   = "11.osmosis"
+	BidId   = "5"
 )
 
 // Global cache instance (cache duration: 30 minutes)
@@ -29,7 +29,7 @@ func computeHoldings(bidId string) (*VenueHoldings, error) {
 	bidConfig := bidMap[bidId]
 
 	// get the protocol config
-	protocolConfig := protocolConfigMap[bidConfig.Protocol]
+	protocolConfig := protocolConfigMap[bidConfig.GetProtocol()]
 
 	// construct the protocol
 	protocol, err := NewDexProtocolFromConfig(protocolConfig, bidConfig)
@@ -47,12 +47,12 @@ func computeHoldings(bidId string) (*VenueHoldings, error) {
 		return nil, fmt.Errorf("error computing TVL: %w", err)
 	}
 
-	addressHoldings, err := protocol.ComputeAddressPrincipalHoldings(assetData, Address)
+	addressHoldings, err := protocol.ComputeAddressPrincipalHoldings(assetData, bidConfig.GetAddress())
 	if err != nil {
 		return nil, fmt.Errorf("error computing address principal holdings: %w", err)
 	}
 
-	rewardHoldings, err := protocol.ComputeAddressRewardHoldings(assetData, Address)
+	rewardHoldings, err := protocol.ComputeAddressRewardHoldings(assetData, bidConfig.GetAddress())
 	if err != nil {
 		return nil, fmt.Errorf("error computing address reward holdings: %w", err)
 	}

--- a/src/osmosis.go
+++ b/src/osmosis.go
@@ -11,14 +11,37 @@ import (
 
 const OsmosisAPIURL = "https://sqs.osmosis.zone"
 
+type OsmosisBidPositionConfig struct {
+	PoolID     string
+	Address    string
+	PositionID string
+}
+
+func (bidConfig OsmosisBidPositionConfig) GetProtocol() Protocol {
+	return Osmosis
+}
+
+func (bidConfig OsmosisBidPositionConfig) GetPoolID() string {
+	return bidConfig.PoolID
+}
+
+func (bidConfig OsmosisBidPositionConfig) GetAddress() string {
+	return bidConfig.Address
+}
+
 // Osmosis implementation
 type OsmosisPosition struct {
 	protocolConfig    ProtocolConfig
-	bidPositionConfig BidPositionConfig
+	bidPositionConfig OsmosisBidPositionConfig
 }
 
-func NewOsmosisPosition(config ProtocolConfig, bidPositionConfig BidPositionConfig) OsmosisPosition {
-	return OsmosisPosition{protocolConfig: config, bidPositionConfig: bidPositionConfig}
+func NewOsmosisPosition(config ProtocolConfig, bidPositionConfig BidPositionConfig) (*OsmosisPosition, error) {
+	osmosisBidPositionConfig, ok := bidPositionConfig.(OsmosisBidPositionConfig)
+	if !ok {
+		return nil, fmt.Errorf("bidPositionConfig must be of OsmosisBidPositionConfig type")
+	}
+
+	return &OsmosisPosition{protocolConfig: config, bidPositionConfig: osmosisBidPositionConfig}, nil
 }
 
 func (p OsmosisPosition) FetchPoolData() (map[string]interface{}, error) {
@@ -108,7 +131,7 @@ func (p OsmosisPosition) ComputeTVL(assetData map[string]interface{}) (*Holdings
 			Amount:      adjustedAmount,
 			CoingeckoID: nil, // Optional field
 			USDValue:    usdValue,
-			DisplayName: &displayName,
+			DisplayName: displayName,
 		}
 		poolAssets = append(poolAssets, asset)
 	}
@@ -176,7 +199,7 @@ func (p *OsmosisPosition) calculateAssetValues(amounts map[string]int64, mapping
 			Amount:      adjustedAmount,
 			CoingeckoID: nil,
 			USDValue:    usdValue,
-			DisplayName: &displayName,
+			DisplayName: displayName,
 		}
 		assets = append(assets, asset)
 	}

--- a/src/types.go
+++ b/src/types.go
@@ -8,6 +8,7 @@ type Protocol string
 const (
 	Osmosis   Protocol = "osmosis"
 	Astroport Protocol = "astroport"
+	Nolus     Protocol = "nolus"
 )
 
 // Core data structures
@@ -18,11 +19,10 @@ const (
 // as well as all the information to identify a
 // concrete position, namely the pool ID,
 // address the position is associated with, and position ID.
-type BidPositionConfig struct {
-	PoolID     string
-	Address    string
-	PositionID string
-	Protocol   Protocol
+type BidPositionConfig interface {
+	GetPoolID() string
+	GetAddress() string
+	GetProtocol() Protocol
 }
 
 // ProtocolConfig holds the configuration for a protocol, independent
@@ -39,7 +39,7 @@ type Asset struct {
 	Amount      float64 `json:"amount"`
 	CoingeckoID *string `json:"coingecko_id,omitempty"`
 	USDValue    float64 `json:"usd_value"`
-	DisplayName *string `json:"display_name,omitempty"`
+	DisplayName string  `json:"display_name,omitempty"`
 }
 
 type Holdings struct {
@@ -64,7 +64,9 @@ type DexProtocol interface {
 func NewDexProtocolFromConfig(config ProtocolConfig, bidPositionConfig BidPositionConfig) (DexProtocol, error) {
 	switch config.Protocol {
 	case Osmosis:
-		return NewOsmosisPosition(config, bidPositionConfig), nil
+		return NewOsmosisPosition(config, bidPositionConfig)
+	case Nolus:
+		return NewNolusPosition(config, bidPositionConfig)
 	}
 
 	return nil, fmt.Errorf("unsupported protocol: %s", config.Protocol)
@@ -77,26 +79,39 @@ var protocolConfigMap = map[Protocol]ProtocolConfig{
 		AssetListURL:      "https://chains.cosmos.directory/osmosis",
 		AddressBalanceUrl: "https://lcd.osmosis.zone/",
 	},
+	Nolus: {
+		Protocol:          Nolus,
+		PoolInfoUrl:       "https://nolus-api.polkachu.com/cosmwasm/wasm/v1/contract",
+		AssetListURL:      "https://chains.cosmos.directory/nolus",
+		AddressBalanceUrl: "",
+	},
 }
 
 // map of bid id to protocol and pool id, position id, address
 var bidMap = map[string]BidPositionConfig{
-	"18": {
-		Protocol:   Osmosis,
+	"18": OsmosisBidPositionConfig{
 		PoolID:     "1283",
 		Address:    "osmo1cuwe7dzgpemwxqzpkhyjwfeev2hcgd9de8xp566hrly6wtpcrc7qgp9jdx",
 		PositionID: "11701290",
 	},
-	"17": {
-		Protocol:   Osmosis,
+	"17": OsmosisBidPositionConfig{
 		PoolID:     "1283",
 		Address:    "osmo1cuwe7dzgpemwxqzpkhyjwfeev2hcgd9de8xp566hrly6wtpcrc7qgp9jdx",
 		PositionID: "11124334",
 	},
-	"11.osmosis": {
-		Protocol:   Osmosis,
+	"11.osmosis": OsmosisBidPositionConfig{
 		PoolID:     "2371",
 		Address:    "osmo1cuwe7dzgpemwxqzpkhyjwfeev2hcgd9de8xp566hrly6wtpcrc7qgp9jdx",
 		PositionID: "11124249",
+	},
+	"5": NolusBidPositionConfig{
+		PoolContractAddress: "nolus1jufcaqm6657xmfltdezzz85quz92rmtd88jk5x0hq9zqseem32ysjdm990",
+		PoolContractToken:   NOLUS_ST_ATOM,
+		Address:             "nolus1u74s6nuqgulf9kuezjt9q8r8ghx0kcvcl96fx63nk29df25n2u5swmz3g6",
+	},
+	"23": NolusBidPositionConfig{
+		PoolContractAddress: "nolus1u0zt8x3mkver0447glfupz9lz6wnt62j70p5fhhtu3fr46gcdd9s5dz9l6",
+		PoolContractToken:   NOLUS_ATOM,
+		Address:             "nolus1u74s6nuqgulf9kuezjt9q8r8ghx0kcvcl96fx63nk29df25n2u5swmz3g6",
 	},
 }


### PR DESCRIPTION
This PR adds support for tracking deployed liquidity on Nolus protocol. Currently we have positions in two of their pools- ATOM and stATOM.

The downside with Nolus is that we can only track the total amount deployed in a pool by Hydro Committee address, and not by the position ID (they don't have this notion at all). This currently works because Nolus had two successful proposals to deploy in different pools.

The rewards for deploying liquidity in both pools is currently 0, which can also be seen in their FE (only for stATOM; for some reason they didn't list ATOM pool on this page): https://app.nolus.io/earn