### PR TITLE
Implemented "all bids holdings" and parametrized "bid holdings" query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module deployment_tracking
 
 go 1.22.2
 
-require github.com/patrickmn/go-cache v2.1.0+incompatible
+require (
+    github.com/patrickmn/go-cache v2.1.0+incompatible
+    github.com/gorilla/mux v1.8.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/src/types.go
+++ b/src/types.go
@@ -74,6 +74,11 @@ type VenueHoldings struct {
 	AddressRewards   Holdings `json:"address_rewards"`
 }
 
+type BidHoldings struct {
+	BidId    string         `json:"bid_id"`
+	Holdings *VenueHoldings `json:"holdings"`
+}
+
 // Protocol interface
 type DexProtocol interface {
 	ComputeTVL(assetData *ChainInfo) (*Holdings, error)


### PR DESCRIPTION
Both queries share the same path: "/holdings/{bid_id}". If no bid ID is provided, query returns holdings of all bid positions.